### PR TITLE
fix: prevent dbus install and add missing xset in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN echo "Begin build" && \
     chmod +x /bin/start-with-autologin-actual.sh && \
     chmod +x /bin/start-port-forwarding.sh && \
     apt-get update && \
-    apt-get install -y apt-utils curl && \
-    apt-get install -y chromium chromium-driver chromium-l10n python3 python3-pip && \
+    apt-get install -y --no-install-recommends --no-install-suggests apt-utils curl x11-xserver-utils && \
+    apt-get install -y --no-install-recommends --no-install-suggests chromium chromium-driver chromium-l10n python3 python3-pip && \
     cd /opt/atrust-autologin && \
     pip3 install --break-system-packages -r requirements.txt && \
     apt-get clean && \


### PR DESCRIPTION
修复了启动容器时 Atrust 无法正常运行、控制台反复打印 “aTrust Port 54631 is not yet being listened on. Waiting for aTrust start ...” 等日志的问题：

- --no-install-recommends --no-install-suggests → 阻止 apt 拉入 dbus-daemon，修复 aTrust 因半残 D-Bus 无法启动的问题
- 显式添加 x11-xserver-utils → 补偿被 --no-install-recommends 移除的 xset 依赖，修复 X11 检测卡住的问题