### PR TITLE
fix：resolve selenium's SessionNotCreatedException in docker and enable local aTrust client detection

### DIFF
--- a/docker/bin/start-with-autologin-actual.sh
+++ b/docker/bin/start-with-autologin-actual.sh
@@ -15,7 +15,7 @@ while true; do
   # 执行命令
   python3 /opt/atrust-autologin/main.py --interactive=True --wait_atrust=True --driver_type=chrome \
   --data_dir="$HOME/.atrust-data" \
-  --driver_path=/usr/bin/chromedriver --browser_path=/usr/bin/chromium $ATRUST_OPTS
+  --driver_path=/usr/bin/chromedriver --browser_path=/usr/bin/chromium --container-mode=True $ATRUST_OPTS
 
   # 检查退出状态码
   if [ $? -eq 0 ]; then

--- a/src/main.py
+++ b/src/main.py
@@ -36,7 +36,7 @@ class ATrustLogin:
         self.cookie_sig = cookie_sig
 
         self.must_be_logged_keywords = ['app_center', 'user_info', 'app_apply', 'device_manage']
-        self.must_not_logged_keywords = ['login', 'totpAuth', 'captcha']
+        # self.must_not_logged_keywords = ['login', 'totpAuth', 'captcha', 'page_auth_trust_terminal', 'smsAuth']
 
         if self.container_mode:
             from selenium.webdriver.chrome.options import Options
@@ -365,13 +365,7 @@ class ATrustLogin:
             return None
 
         url = urlparse(self.driver.current_url)
-
-        if any(keyword in url.fragment for keyword in self.must_be_logged_keywords):
-            return True
-        if any(keyword in url.fragment for keyword in self.must_not_logged_keywords):
-            return False
-
-        return "工作台" in self.driver.page_source and "本地密码" not in self.driver.page_source
+        return any(keyword in url.fragment for keyword in self.must_be_logged_keywords)
 
     def close(self):
         self.driver.quit()

--- a/src/main.py
+++ b/src/main.py
@@ -23,8 +23,9 @@ class ATrustLoginStorage(BaseModel):
     local_storage: Dict[str, Any]
 
 class ATrustLogin:
-    def __init__(self, portal_address, driver_path=None, browser_path=None, driver_type=None, data_dir="data", cookie_tid=None, cookie_sig=None, interactive=False):
+    def __init__(self, portal_address, driver_path=None, browser_path=None, driver_type=None, data_dir="data", cookie_tid=None, cookie_sig=None, interactive=False, container_mode=False):
         self.initialized = False
+        self.container_mode = container_mode
         if not os.path.exists(data_dir):
             os.makedirs(data_dir, exist_ok=True)
         self.data_dir = data_dir
@@ -37,49 +38,10 @@ class ATrustLogin:
         self.must_be_logged_keywords = ['app_center', 'user_info', 'app_apply', 'device_manage']
         self.must_not_logged_keywords = ['login', 'totpAuth', 'captcha']
 
-        if driver_type is None:
-            system = platform.system()
-            if system == "Windows":
-                driver_type = "edge"
-            else:
-                driver_type = "chrome"
-
-        logger.debug(f"Driver: {driver_type}: {driver_path}")
-
-        if driver_type == "edge":
-            from selenium.webdriver.edge.options import Options
-            from selenium.webdriver.edge.service import Service
-
-            self.options = Options()
-            self.options.add_argument("--user-data-dir=/tmp/edge-data")
-            self.options.add_argument('--profile-directory=ATrustLogin')
-            self.options.add_argument("--ignore-certificate-errors")
-            self.options.add_argument("--ignore-ssl-errors")
-            self.options.add_argument("--no-sandbox")
-            self.options.add_argument("--lang=zh-CN")
-            self.options.add_argument("--disable-gpu")
-            self.options.add_argument("--disable-extensions")
-            self.options.add_argument("--disable-web-security")
-            self.options.add_argument("--allow-insecure-localhost")
-            self.options.add_argument("--window-size=896,672")
-            if browser_path is not None:
-                self.options.binary_location = browser_path
-
-            self.options.add_experimental_option("prefs", {
-                "intl.accept_languages": "zh-CN",
-                "protocol_handler": {
-                    "allowed_origin_protocol_pairs": {
-                        self.portal_address: {"atrust": True}
-                    }
-                }
-            })
-
-            self.driver = webdriver.Edge(service=Service(driver_path), options=self.options)
-
-        else:
+        if self.container_mode:
             from selenium.webdriver.chrome.options import Options
 
-            DEBUG_PORT = "12345"
+            DEBUG_PORT = "55555"
             PROFILE_DIR = "Default"
 
             binary_location = browser_path or "/usr/bin/chromium"
@@ -118,14 +80,43 @@ class ATrustLogin:
                     time.sleep(3)
 
             self.options = Options()
-            self.options.add_experimental_option("prefs", {
-                "intl.accept_languages": "zh-CN",
-                "protocol_handler.allowed_origin_protocol_pairs": {
-                    self.portal_address: {"atrust": True}
-                }
-            })
             self.options.debugger_address = f"127.0.0.1:{DEBUG_PORT}"
             self.driver = webdriver.Chrome(options=self.options)
+
+        else:
+            if driver_type is None:
+                system = platform.system()
+                if system == "Windows":
+                    driver_type = "edge"
+                else:
+                    driver_type = "chrome"
+
+            logger.debug(f"Driver: {driver_type}: {driver_path}")
+
+            if driver_type == "edge":
+                from selenium.webdriver.edge.options import Options
+                from selenium.webdriver.edge.service import Service
+                driver_cls = webdriver.Edge
+            else:
+                from selenium.webdriver.chrome.options import Options
+                from selenium.webdriver.chrome.service import Service
+                driver_cls = webdriver.Chrome
+
+            self.options = Options()
+            self.options.add_argument('--profile-directory=ATrustLogin')
+            self.options.add_argument("--ignore-certificate-errors")
+            self.options.add_argument("--ignore-ssl-errors")
+            self.options.add_argument("--no-sandbox")
+            self.options.add_argument("--lang=zh-CN")
+            self.options.add_argument("--disable-gpu")
+            self.options.add_argument("--disable-extensions")
+            self.options.add_argument("--disable-web-security")
+            self.options.add_argument("--allow-insecure-localhost")
+            self.options.add_argument("--window-size=896,672")
+            self.options.add_experimental_option("prefs", {"intl.accept_languages": "zh-CN"})
+            if browser_path is not None:
+                self.options.binary_location = browser_path
+            self.driver = driver_cls(service=Service(driver_path), options=self.options)
 
         self.wait = WebDriverWait(self.driver, 10)
         logger.debug("Selenium init successfully.")
@@ -384,7 +375,7 @@ class ATrustLogin:
 
     def close(self):
         self.driver.quit()
-        if hasattr(self, 'chrome_process') and self.chrome_process.poll() is None:
+        if self.container_mode and hasattr(self, 'chrome_process') and self.chrome_process.poll() is None:
             self.chrome_process.terminate()
             try:
                 self.chrome_process.wait(timeout=5)
@@ -422,14 +413,14 @@ class ATrustLogin:
                     logger.info(f"aTrust Port {port} is not yet being listened on. Waiting for aTrust start ...")
                     ATrustLogin.delay_loading()
 
-def main(portal_address, username, password, totp_key=None, cookie_tid=None, cookie_sig=None, keepalive=200, data_dir="./data", driver_type=None, driver_path=None, browser_path=None, interactive=False, wait_atrust=True):
+def main(portal_address, username, password, totp_key=None, cookie_tid=None, cookie_sig=None, keepalive=200, data_dir="./data", driver_type=None, driver_path=None, browser_path=None, interactive=False, wait_atrust=True, container_mode=False):
     logger.info("Opening Web Browser")
 
     if wait_atrust:
         ATrustLogin.wait_for_port(54631)
 
     # 创建ATrustLogin对象
-    at = ATrustLogin(data_dir=data_dir, portal_address=portal_address, cookie_tid=cookie_tid, cookie_sig=cookie_sig, driver_type=driver_type, driver_path=driver_path, browser_path=browser_path, interactive=interactive)
+    at = ATrustLogin(data_dir=data_dir, portal_address=portal_address, cookie_tid=cookie_tid, cookie_sig=cookie_sig, driver_type=driver_type, driver_path=driver_path, browser_path=browser_path, interactive=interactive, container_mode=container_mode)
 
     at.init()
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,8 +1,11 @@
+import json
 import os.path
 import pickle
 import platform
 import socket
+import subprocess
 import time
+import urllib.request
 from typing import Dict, List, Any
 from urllib.parse import urlparse
 
@@ -46,38 +49,82 @@ class ATrustLogin:
         if driver_type == "edge":
             from selenium.webdriver.edge.options import Options
             from selenium.webdriver.edge.service import Service
-        else :
-            from selenium.webdriver.chrome.service import Service
+
+            self.options = Options()
+            self.options.add_argument("--user-data-dir=/tmp/edge-data")
+            self.options.add_argument('--profile-directory=ATrustLogin')
+            self.options.add_argument("--ignore-certificate-errors")
+            self.options.add_argument("--ignore-ssl-errors")
+            self.options.add_argument("--no-sandbox")
+            self.options.add_argument("--lang=zh-CN")
+            self.options.add_argument("--disable-gpu")
+            self.options.add_argument("--disable-extensions")
+            self.options.add_argument("--window-size=896,672")
+            if browser_path is not None:
+                self.options.binary_location = browser_path
+
+            self.options.add_experimental_option("prefs", {
+                "intl.accept_languages": "zh-CN",
+                "protocol_handler": {
+                    "allowed_origin_protocol_pairs": {
+                        self.portal_address: {"atrust": True}
+                    }
+                }
+            })
+
+            self.driver = webdriver.Edge(service=Service(driver_path), options=self.options)
+
+        else:
             from selenium.webdriver.chrome.options import Options
 
-        # 配置Edge Driver选项
-        self.options = Options()
+            DEBUG_PORT = "12345"
+            PROFILE_DIR = "Default"
 
-        # self.options.add_argument(f'--user-data-dir="{data_dir}"')
-        self.options.add_argument(f'--profile-directory=ATrustLogin')
-        # options.add_argument("--start-maximized")
-        self.options.add_argument("--ignore-certificate-errors")
-        self.options.add_argument("--ignore-ssl-errors")
-        self.options.add_argument("--no-sandbox")
-        self.options.add_argument("--lang=zh-CN")
-        self.options.add_argument("--disable-gpu")
-        self.options.add_argument("--disable-extensions")
-        self.options.add_argument("--window-size=896,672")
+            binary_location = browser_path or "/usr/bin/chromium"
+            chrome_data_dir = os.path.join("/tmp", "chrome-data")
+            log_file = os.path.join(chrome_data_dir, "chrome.log")
+            os.makedirs(chrome_data_dir, exist_ok=True)
 
-        self.options.add_experimental_option("prefs", {"intl.accept_languages": "zh-CN"})
+            logger.info(f"Starting Chrome with debug port {DEBUG_PORT}")
+            self.chrome_process = subprocess.Popen([
+                    binary_location,
+                    f"--remote-debugging-port={DEBUG_PORT}",
+                    f"--user-data-dir={chrome_data_dir}",
+                    f"--profile-directory={PROFILE_DIR}",
+                    "--ignore-certificate-errors",
+                    "--ignore-ssl-errors", 
+                    "--no-sandbox", 
+                    "--lang=zh-CN", 
+                    "--disable-gpu", 
+                    "--disable-extensions",
+                    "--window-size=896,672",
+                    "data:,"
+                ], stdout=open(log_file, "w"), stderr=subprocess.STDOUT
+            )
 
-        if browser_path is not None:
-            self.options.binary_location = browser_path
+            logger.info(f"Chrome started, PID {self.chrome_process.pid}, waiting for DevTools ...")
+            while True:
+                if self.chrome_process.poll() is not None:
+                    raise RuntimeError(f"Chrome exited with code {self.chrome_process.returncode}")
+                try:
+                    urllib.request.urlopen(f"http://127.0.0.1:{DEBUG_PORT}/json/version")
+                    logger.info("DevTools ready.")
+                    break
+                except:
+                    time.sleep(3)
 
-        # 初始化Edge Driver
-        service = Service(driver_path)
-
-        if driver_type == "edge":
-            self.driver = webdriver.Edge(service=service, options=self.options)
-        else :
-            self.driver = webdriver.Chrome(service=service, options=self.options)
+            self.options = Options()
+            self.options.add_experimental_option("prefs", {
+                "intl.accept_languages": "zh-CN",
+                "protocol_handler.allowed_origin_protocol_pairs": {
+                    self.portal_address: {"atrust": True}
+                }
+            })
+            self.options.debugger_address = f"127.0.0.1:{DEBUG_PORT}"
+            self.driver = webdriver.Chrome(options=self.options)
 
         self.wait = WebDriverWait(self.driver, 10)
+        logger.debug("Selenium init successfully.")
 
     # 打开默认的portal地址并等待sangfor_main_auth_container出现
     def open_portal(self):
@@ -333,6 +380,13 @@ class ATrustLogin:
 
     def close(self):
         self.driver.quit()
+        if hasattr(self, 'chrome_process') and self.chrome_process.poll() is None:
+            self.chrome_process.terminate()
+            try:
+                self.chrome_process.wait(timeout=5)
+            except:
+                self.chrome_process.kill()
+                self.chrome_process.wait()
 
     def __enter__(self):
         return self

--- a/src/main.py
+++ b/src/main.py
@@ -59,6 +59,8 @@ class ATrustLogin:
             self.options.add_argument("--lang=zh-CN")
             self.options.add_argument("--disable-gpu")
             self.options.add_argument("--disable-extensions")
+            self.options.add_argument("--disable-web-security")
+            self.options.add_argument("--allow-insecure-localhost")
             self.options.add_argument("--window-size=896,672")
             if browser_path is not None:
                 self.options.binary_location = browser_path
@@ -97,6 +99,8 @@ class ATrustLogin:
                     "--lang=zh-CN", 
                     "--disable-gpu", 
                     "--disable-extensions",
+                    "--disable-web-security",
+                    "--allow-insecure-localhost",
                     "--window-size=896,672",
                     "data:,"
                 ], stdout=open(log_file, "w"), stderr=subprocess.STDOUT


### PR DESCRIPTION
修复启动容器时 Selenium 报错 SessionNotCreatedException 导致脚本无法运作问题；修复浏览器提示xxx wants to access other apps and services on this device，必须要手动点允许，才能检测到 aTrust 本地客户端问题；简化登入检测。

## 问题

1. ChromeDriver 150 版本似乎无法创建会话：Chromium 150 + ChromeDriver 150 在 Docker 容器中组合使用时，ChromeDriver 管理的 Chrome 子进程在初始化阶段无法通过安全检查导致立即退出（SIGTRAP），Selenium 报错 SessionNotCreatedException
2. aTrust 门户页无法检测本地客户端：门户页通过 XHR 请求 https://127.0.0.1:54630/v1/detect 检测本地 aTrust 服务，但 Chrome 的 Private Network Access（PNA）机制阻止了公开网站访问私有网络地址，需要用户手动在弹窗中点击 Allow 才能通行

## 解决

核心思路：引入 --container-mode 参数指定，将 Docker 环境下的 workaround 与直接运行场景分离。

### Docker 容器模式（--container-mode=True）

- 启动脚本 start-with-autologin-actual.sh 补充 --container-mode=True
- 不再让 ChromeDriver 管理 Chrome 子进程生命周期，改为 Python subprocess.Popen 启动 Chrome + 固定调试端口（55555），避免 ChromeDriver 启动时因安全检查触发的 SIGTRAP
- 保持 --profile-directory 为默认（Chromium 150 在非 Default profile 名时触发断言崩溃）
- 添加 --disable-web-security + --allow-insecure-localhost，绕过 PNA 检查，使 aTrust 门户页的 XHR 检测请求直达本地客户端

### 直接运行模式（--container-mode=False，默认）

- 基本保持原流程
- 同样添加 --disable-web-security + --allow-insecure-localhost，绕过 PNA 检查

## 其他优化

is_logged 方法简化：仅检查 must_be_logged_keywords 即可